### PR TITLE
Return rendered value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export async function renderWith(
   require: (dep: string) => any,
   storyResult: unknown,
   div: HTMLElement
-): Promise<void> {
+): Promise<boolean | VoidFunction> {
   const storyType = typeOf(storyResult);
   const rendered = await render(require, storyResult, storyType, div);
   if (!rendered) {
@@ -27,4 +27,5 @@ export async function renderWith(
       }
     }
   }
+  return rendered;
 }


### PR DESCRIPTION
This is the bit that was missing on the dispose function feature. This package needs to return it so the studio can take the function and execute it. We could rename the `rendered` variable. Happy to hear proposals if any.